### PR TITLE
Fixed installation failure.

### DIFF
--- a/vsconsoleoutput.plugin.vs/source.extension.vsixmanifest
+++ b/vsconsoleoutput.plugin.vs/source.extension.vsixmanifest
@@ -10,7 +10,7 @@
         <PreviewImage>resource\picture\preview.png</PreviewImage>
         <Tags>Console;Output;</Tags>
     </Metadata>
-    <Installation AllUsers="true" InstalledByMsi="true">
+    <Installation AllUsers="true">
         <InstallationTarget Version="[17.0, 18.0)" Id="Microsoft.VisualStudio.Community">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>


### PR DESCRIPTION
Fix for #1 

Removed `InstalledByMsi`, this attribute is optional with `false` default value that indicates that package is managed by Visual Studio Extension Manager. 
see
https://learn.microsoft.com/en-us/visualstudio/extensibility/vsix-extension-schema-2-0-reference?view=vs-2022#installation-element